### PR TITLE
Fix AWS S3 bucket name to prevent privacy error on AWS hosted images

### DIFF
--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -3,6 +3,7 @@
   <div class="pretty_form">
     <h2>Edit Project</h2>
     <%= render "form" %>
+  </div>
 <% else %>
   <h2>Login to edit Project</h2>
   You need to <%= link_to "Sign in", [:new, :session] %> or <%= link_to "Sign up", [:new, :user] %> to edit a project.

--- a/config/initializers/fog.rb
+++ b/config/initializers/fog.rb
@@ -7,5 +7,5 @@ CarrierWave.configure do |config|
     path_style: true
   }
 
-  config.fog_directory = "gph.images"
+  config.fog_directory = "gphimages"
 end

--- a/db/migrate/20140913211302_change_user_image_default.rb
+++ b/db/migrate/20140913211302_change_user_image_default.rb
@@ -1,0 +1,5 @@
+class ChangeUserImageDefault < ActiveRecord::Migration
+  def up
+    change_column :users, :image, :string, default: "DefaultAvatar.jpg"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140909144117) do
+ActiveRecord::Schema.define(version: 20140913211302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,14 +71,14 @@ ActiveRecord::Schema.define(version: 20140909144117) do
   add_index "projects", ["title", "user_id"], name: "index_projects_on_title_and_user_id", unique: true, using: :btree
 
   create_table "users", force: true do |t|
-    t.string   "email",                                            null: false
-    t.string   "name",                                             null: false
-    t.string   "password_digest",                                  null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.boolean  "account_enabled", default: true,                   null: false
-    t.boolean  "site_admin",      default: false,                  null: false
-    t.string   "image",           default: "uploads/User/image/1"
+    t.string   "email",                                         null: false
+    t.string   "name",                                          null: false
+    t.string   "password_digest",                               null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.boolean  "account_enabled", default: true,                null: false
+    t.boolean  "site_admin",      default: false,               null: false
+    t.string   "image",           default: "DefaultAvatar.jpg"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
The bucket name in aws s3 had a . in it, causing a security error, which prevented images from displaying. Fixed. 
I'm not sure why the add images to users code is showing up as new in this commit, since it's unchanged from prior commits.
