### PR TITLE
Make success stories index layout match projects index layout

### DIFF
--- a/app/views/success_stories/index.html.erb
+++ b/app/views/success_stories/index.html.erb
@@ -1,7 +1,5 @@
-<div class="hero-unit">
+<div class="show_block success_stories_show">
   <h1>Success Stories</h1>
-</div>
-<div class="container">
   <div class="row">
     <% @success_stories.each do |story| %>
       <div class="success_stories_show_block col-md-6">


### PR DESCRIPTION
Use the same css for the success stories index page as is used on the projects index page.
