### PR TITLE
Remove green boxes from home page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require bootstrap
 //= require jquery_ujs
+//= require bootstrap
 //= require_tree .

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -340,9 +340,9 @@ USE THIS TO GIVE HERO UNIT AN IMAGE BACKGROUND:
 
 .show_block {
   display: inline-block;
-  padding: 15px 35px;
+  padding: 1em 4em;
   font-size: 1.2em;
-  @include box_rounded_shadow;
+  @include box_rounded_no_shadow;
 
   .categories_show {
     display: block;

--- a/app/views/dashboards/_projects_you_funded.html.erb
+++ b/app/views/dashboards/_projects_you_funded.html.erb
@@ -1,8 +1,11 @@
 <h2>You've Funded</h2>
 <% if current_user.donated_to.any? %>
-  <% current_user.donated_to.each do |project|  %>
-    <h4><%= image_tag project.image_url(:thumb) %> <%= link_to project.title, project %></h4>
-    Raised so far: <%= number_to_currency project.received_donations %>
+  <% current_user.donated_to.each do |project| %>
+    <div class="thumb_list_wrapper">
+      <span class="thumb_left"><%= image_tag project.image_url(:thumb) %></span>
+      <span class="no_image_wrap"><%= link_to project.title, project %><br />
+      Raised so far: <%= number_to_currency project.received_donations %></span>
+    </div>
   <% end %>
 <% else %>
     Oh no! You haven't funded any projects yet. Projects await you, hero!

--- a/app/views/dashboards/_your_projects.html.erb
+++ b/app/views/dashboards/_your_projects.html.erb
@@ -1,9 +1,12 @@
 <h2>Your Projects</h2>
 <% if current_user.projects.any? %>
   <% current_user.projects.each do |project| %>
-    <h4><%= image_tag project.image_url(:thumb) %> <%= link_to project.title, project %></h4>
-    Needed: <%= number_to_currency project.cost %>,
-     Raised: <%= number_to_currency project.received_donations %>
+    <div class="thumb_list_wrapper">
+      <span class="thumb_left"><%= image_tag project.image_url(:thumb) %></span>
+      <span class="no_image_wrap"><%= link_to project.title, project %><br />
+      Needed: <%= number_to_currency project.cost %>,
+      Raised: <%= number_to_currency project.received_donations %></span>
+    </div>
   <% end %>
 <% else %>
   You haven't created any projects.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <%= stylesheet_link_tag  "application" %>
     <%= javascript_include_tag 'application', media: 'all' %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%= stylesheet_link_tag  "application" %>
     <%= csrf_meta_tags %>
     <title>GreenPlanetHeroes</title>
   </head>

--- a/lib/generate_column_widths.rb
+++ b/lib/generate_column_widths.rb
@@ -1,5 +1,9 @@
 module GenerateColumnWidths
-  def generate_widths(new_columns, total_grid_columns: 12, existing_columns: 0, min_column_span: 3, max_column_span: 12)
+  def generate_widths(new_columns,
+                      total_grid_columns: 12,
+                      existing_columns: 0,
+                      min_column_span: 3,
+                      max_column_span: 12)
     columns_in_row = new_columns + existing_columns
     span = (total_grid_columns / columns_in_row).floor
 


### PR DESCRIPTION
Remove boxes from around Your Projects and Projects You've funded.
Properly align text next to thumbnails in project list.
Improve readability of generate widths module.
